### PR TITLE
[Feat] kakao API를 활용하여 회원가입/로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.28'
 	//kakao api 할 때 필요 : Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 
 
 }

--- a/src/main/java/com/example/back/teamate/TeamateApplication.java
+++ b/src/main/java/com/example/back/teamate/TeamateApplication.java
@@ -1,9 +1,15 @@
 package com.example.back.teamate;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import jakarta.annotation.PostConstruct;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TeamateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/back/teamate/config/RedisConfig.java
+++ b/src/main/java/com/example/back/teamate/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.example.back.teamate.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory);
+
+		// JSON 직렬화기 설정
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(getObjectMapper());
+
+		// Key와 Value 직렬화기 설정
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(serializer);
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(serializer);
+
+		template.afterPropertiesSet();
+		return template;
+	}
+
+	private ObjectMapper getObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		// 타입 정보를 JSON에 포함하도록 설정
+		objectMapper.activateDefaultTyping(
+			objectMapper.getPolymorphicTypeValidator(),
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
+		return objectMapper;
+	}
+}

--- a/src/main/java/com/example/back/teamate/controller/KakaoController.java
+++ b/src/main/java/com/example/back/teamate/controller/KakaoController.java
@@ -1,0 +1,92 @@
+package com.example.back.teamate.controller;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.back.teamate.dto.AccessTokenResponseDto;
+import com.example.back.teamate.dto.KakaoTokenResponseDto;
+import com.example.back.teamate.dto.KakaoUserInfoResponseDto;
+import com.example.back.teamate.dto.RedisUserInfoDto;
+import com.example.back.teamate.service.KakaoService;
+import com.example.back.teamate.service.UsersService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class KakaoController {
+
+	private final KakaoService kakaoService;
+	private final UsersService usersService;
+
+	@GetMapping("/auth/callback")
+	public ResponseEntity<?> getTokens(@RequestParam("code") String code) {
+		try {
+			// 1. 토큰 발급
+			KakaoTokenResponseDto tokens = kakaoService.getTokensFromKakao(code);
+
+
+			return ResponseEntity.ok(tokens.getAccessToken());
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("오류 발생: " + e.getMessage());
+		}
+	}
+
+	@GetMapping("/login")
+	public ResponseEntity<?> loginWithKakao(@RequestParam String code) {
+		// 1. 인증 코드로 Kakao Access Token 가져오기
+		KakaoTokenResponseDto tokenResponse = kakaoService.getTokensFromKakao(code);
+
+		// 2. Access Token으로 사용자 정보 가져오기
+		KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(tokenResponse.getAccessToken());
+
+		// 3. 사용자 정보로 회원가입 또는 로그인 처리
+		RedisUserInfoDto userData = usersService.registerOrLogin(userInfo);
+
+		// 4. Redis에 사용자 정보 저장
+		usersService.saveToken(tokenResponse.getAccessToken(), userData);
+
+		// 5. 사용자 정보 반환 (Bearer 포함)
+		return ResponseEntity.ok(AccessTokenResponseDto.builder()
+			.accessToken("Bearer " + tokenResponse.getAccessToken())
+			.userData(userData) // 사용자 정보를 함께 반환
+			.build());
+	}
+
+
+
+	@PostMapping("/logout")
+	public ResponseEntity<?> logout(@RequestHeader("Authorization") String authHeader) {
+		try {
+			String accessToken = authHeader.startsWith("Bearer ") ? authHeader.substring(7) : authHeader;
+			usersService.logout(accessToken);
+			return ResponseEntity.ok("로그아웃 되었습니다.");
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그아웃 실패");
+		}
+	}
+
+
+	@GetMapping("/unlink")
+	public ResponseEntity<?> unlinkKakao(@RequestHeader("Authorization") String authHeader) {
+		try {
+			String accessToken = authHeader.startsWith("Bearer ") ? authHeader.substring(7) : authHeader;
+			kakaoService.unlinkUser(accessToken);
+			return ResponseEntity.ok("연결이 해제되었습니다.");
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("오류 발생: " + e.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/com/example/back/teamate/controller/KakaoLoginPageController.java
+++ b/src/main/java/com/example/back/teamate/controller/KakaoLoginPageController.java
@@ -1,4 +1,4 @@
-package com.example.back.teamate.kakao;
+package com.example.back.teamate.controller;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/login")
+@RequestMapping("/api/v1/login")
 public class KakaoLoginPageController {
 
 	@Value("${kakao.client_id}")

--- a/src/main/java/com/example/back/teamate/controller/UsersController.java
+++ b/src/main/java/com/example/back/teamate/controller/UsersController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.back.teamate.dto.RedisUserInfoDto;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class UsersController {
 
 	private final UsersService usersService;

--- a/src/main/java/com/example/back/teamate/controller/UsersController.java
+++ b/src/main/java/com/example/back/teamate/controller/UsersController.java
@@ -1,0 +1,34 @@
+package com.example.back.teamate.controller;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.back.teamate.dto.RedisUserInfoDto;
+import com.example.back.teamate.service.UsersService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class UsersController {
+
+	private final UsersService usersService;
+
+	@GetMapping("/secure-endpoint")
+	public ResponseEntity<?> secureEndpoint(@RequestHeader("Authorization") String authHeader) {
+		try {
+			String accessToken = authHeader.startsWith("Bearer ") ? authHeader.substring(7) : authHeader;
+			RedisUserInfoDto userData = usersService.validateToken(accessToken);
+			return ResponseEntity.ok("Hello, " + userData.getNickname());
+		} catch (RuntimeException e) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+		}
+	}
+
+
+}

--- a/src/main/java/com/example/back/teamate/dto/AccessTokenResponseDto.java
+++ b/src/main/java/com/example/back/teamate/dto/AccessTokenResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.back.teamate.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AccessTokenResponseDto {
+	private String accessToken;
+	private RedisUserInfoDto userData; // 사용자 정보
+}

--- a/src/main/java/com/example/back/teamate/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/com/example/back/teamate/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.back.teamate.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor //역직렬화를 위한 기본 생성자
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDto {
+
+	@JsonProperty("token_type")
+	public String tokenType;
+	@JsonProperty("access_token")
+	public String accessToken;
+	@JsonProperty("id_token")
+	public String idToken;
+	@JsonProperty("expires_in")
+	public Integer expiresIn;
+	@JsonProperty("refresh_token")
+	public String refreshToken;
+	@JsonProperty("refresh_token_expires_in")
+	public Integer refreshTokenExpiresIn;
+	@JsonProperty("scope")
+	public String scope;
+}

--- a/src/main/java/com/example/back/teamate/dto/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/example/back/teamate/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,74 @@
+package com.example.back.teamate.dto;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDto {
+
+	@JsonProperty("id")
+	private Long id;
+
+	@JsonProperty("properties")
+	private Map<String, String> properties;
+
+	@JsonProperty("kakao_account")
+	private KakaoAccount kakaoAccount;
+
+	@Getter
+	@NoArgsConstructor
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class KakaoAccount {
+
+		@JsonProperty("profile_needs_agreement")
+		private Boolean profileNeedsAgreement;
+
+		@JsonProperty("profile_nickname_needs_agreement")
+		private Boolean profileNicknameNeedsAgreement;
+
+		@JsonProperty("profile_image_needs_agreement")
+		private Boolean profileImageNeedsAgreement;
+
+		@JsonProperty("profile")
+		private Profile profile;
+
+		@JsonProperty("email_needs_agreement")
+		private Boolean emailNeedsAgreement;
+
+		@JsonProperty("is_email_valid")
+		private Boolean isEmailValid;
+
+		@JsonProperty("is_email_verified")
+		private Boolean isEmailVerified;
+
+		@JsonProperty("email")
+		private String email;
+
+		@Getter
+		@NoArgsConstructor
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		public static class Profile {
+			@JsonProperty("nickname")
+			private String nickname;
+
+			@JsonProperty("thumbnail_image_url")
+			private String thumbnailImageUrl;
+
+			@JsonProperty("profile_image_url")
+			private String profileImageUrl;
+
+			@JsonProperty("is_default_image")
+			private Boolean isDefaultImage;
+
+			@JsonProperty("is_default_nickname")
+			private Boolean isDefaultNickname;
+		}
+	}
+}

--- a/src/main/java/com/example/back/teamate/dto/RedisUserInfoDto.java
+++ b/src/main/java/com/example/back/teamate/dto/RedisUserInfoDto.java
@@ -1,0 +1,17 @@
+package com.example.back.teamate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class RedisUserInfoDto {
+
+	private Long id;
+	private Long kakaoId;
+	private String nickname;
+}

--- a/src/main/java/com/example/back/teamate/entity/BaseEntity.java
+++ b/src/main/java/com/example/back/teamate/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.example.back.teamate.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+	@Column(nullable = false, updatable = false)
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@Column(nullable = false)
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/back/teamate/entity/Users.java
+++ b/src/main/java/com/example/back/teamate/entity/Users.java
@@ -1,0 +1,63 @@
+package com.example.back.teamate.entity;
+
+import com.example.back.teamate.enums.BasicEnums;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Users extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id; // 사용자 ID
+
+	@Column(nullable = false, unique = true)
+	private Long kakaoId; // 카카오 사용자 ID
+
+	@Column(nullable = false)
+	private String email; // 이메일
+
+	private String phoneNumber; // 전화번호 (선택 동의)
+	private String nickname; // 닉네임
+	private String profileImage; // 프로필 이미지
+
+	private int age; // 나이
+
+	@Enumerated(EnumType.STRING)
+	private BasicEnums.Job job; // 직업
+
+	@Enumerated(EnumType.STRING)
+	private BasicEnums.Gender gender; // 성별
+
+	@Enumerated(EnumType.STRING)
+	private BasicEnums.MBTI mbti; // MBTI
+
+	@Enumerated(EnumType.STRING)
+	private BasicEnums.Position position; // 포지션
+
+	@Enumerated(EnumType.STRING)
+	private BasicEnums.Mode mode; // 선호방식
+
+	@Enumerated(EnumType.STRING)
+	private BasicEnums.Region region; // 대권역
+
+	private String city; // 도시
+	private String district; // 구
+
+	private boolean isActiveProject; // 프로젝트 활성화 여부
+	private boolean isActiveStudy; // 스터디 활성화 여부
+
+	// 추가 메서드 (전화번호, 이메일 변경 등)
+	public void changePhoneNumber(String newPhoneNumber) {
+		this.phoneNumber = newPhoneNumber;
+	}
+
+	public void changeEmail(String newEmail) {
+		this.email = newEmail;
+	}
+}

--- a/src/main/java/com/example/back/teamate/enums/BasicEnums.java
+++ b/src/main/java/com/example/back/teamate/enums/BasicEnums.java
@@ -1,0 +1,126 @@
+package com.example.back.teamate.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+public class BasicEnums {
+
+	@RequiredArgsConstructor
+	public enum Job {
+		STUDENT("학생"),
+		JOB_SEEKER("취준생"),
+		OFFICE_WORKER("직장인"),
+		POSTGRADUATE_STUDENT("대학원생");
+
+		private final String koreanName;
+
+		@JsonValue
+		public String getKoreanName() {
+			return koreanName;
+		}
+
+		@JsonCreator
+		public static Job fromKoreanName(String koreanName) {
+			return Arrays.stream(values())
+				.filter(job -> job.koreanName.equals(koreanName))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 직업: " + koreanName));
+		}
+	}
+
+	@RequiredArgsConstructor
+	public enum Gender {
+		MALE("남성"),
+		FEMALE("여성");
+
+		private final String koreanName;
+
+		@JsonValue
+		public String getKoreanName() {
+			return koreanName;
+		}
+
+		@JsonCreator
+		public static Gender fromKoreanName(String koreanName) {
+			return Arrays.stream(values())
+				.filter(gender -> gender.koreanName.equals(koreanName))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 성별: " + koreanName));
+		}
+	}
+
+	public enum MBTI {
+		INTJ, INTP, ENTJ, ENTP, INFJ, INFP, ENFJ, ENFP, ISTJ, ISFJ, ESTJ, ESFJ, ISTP, ISFP, ESTP, ESFP;
+	}
+
+	@RequiredArgsConstructor
+	public enum Position {
+		FRONTEND("프론트엔드"),
+		BACKEND("백엔드"),
+		FULLSTACK("풀스택"),
+		DESIGNER("디자이너"),
+		PM("프로젝트 매니저"),
+		OTHER("기타");
+
+		private final String koreanName;
+
+		@JsonValue
+		public String getKoreanName() {
+			return koreanName;
+		}
+
+		@JsonCreator
+		public static Position fromKoreanName(String koreanName) {
+			return Arrays.stream(values())
+				.filter(position -> position.koreanName.equals(koreanName))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 포지션: " + koreanName));
+		}
+	}
+
+	@RequiredArgsConstructor
+	public enum Mode {
+		ONLINE("온라인"),
+		OFFLINE("오프라인");
+
+		private final String koreanName;
+
+		@JsonValue
+		public String getKoreanName() {
+			return koreanName;
+		}
+
+		@JsonCreator
+		public static Mode fromKoreanName(String koreanName) {
+			return Arrays.stream(values())
+				.filter(mode -> mode.koreanName.equals(koreanName))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 모드: " + koreanName));
+		}
+	}
+
+	@RequiredArgsConstructor
+	public enum Region {
+		SEOUL("서울"),
+		GYEONGGI("경기"),
+		INCHEON("인천");
+
+		private final String koreanName;
+
+		@JsonValue
+		public String getKoreanName() {
+			return koreanName;
+		}
+
+		@JsonCreator
+		public static Region fromKoreanName(String koreanName) {
+			return Arrays.stream(values())
+				.filter(region -> region.koreanName.equals(koreanName))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 지역: " + koreanName));
+		}
+	}
+}

--- a/src/main/java/com/example/back/teamate/repository/UsersRepository.java
+++ b/src/main/java/com/example/back/teamate/repository/UsersRepository.java
@@ -1,0 +1,11 @@
+package com.example.back.teamate.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.back.teamate.entity.Users;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+	Optional<Users> findByKakaoId(Long kakaoId);
+}

--- a/src/main/java/com/example/back/teamate/service/KakaoService.java
+++ b/src/main/java/com/example/back/teamate/service/KakaoService.java
@@ -1,0 +1,74 @@
+package com.example.back.teamate.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import com.example.back.teamate.dto.KakaoTokenResponseDto;
+import com.example.back.teamate.dto.KakaoUserInfoResponseDto;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+public class KakaoService {
+
+	@Value("${kakao.client_id}")
+	private String clientId;
+
+	@Value("${kakao.redirect_uri}")
+	private String redirectUri;
+
+	private String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
+
+	private String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+
+	private final WebClient webClient = WebClient.builder()
+		.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+		.build();
+
+	public KakaoTokenResponseDto getTokensFromKakao(String code) {
+		try {
+			return webClient.post()
+				.uri(KAUTH_TOKEN_URL_HOST + "/oauth/token")
+				.body(BodyInserters.fromFormData("grant_type", "authorization_code")
+					.with("client_id", clientId)
+					.with("redirect_uri", redirectUri)
+					.with("code", code))
+				.retrieve()
+				.bodyToMono(KakaoTokenResponseDto.class)
+				.block();
+		} catch (WebClientResponseException e) {
+			log.error("Failed to retrieve tokens for code {}: {}", code, e.getResponseBodyAsString());
+			throw new RuntimeException("Failed to retrieve tokens for code: " + code, e);
+		}
+	}
+
+	public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+		return webClient.get()
+			.uri(KAUTH_USER_URL_HOST + "/v2/user/me")
+			.header(HttpHeaders.AUTHORIZATION, accessToken.startsWith("Bearer ") ? accessToken : "Bearer " + accessToken)
+			.retrieve()
+			.bodyToMono(KakaoUserInfoResponseDto.class)
+			.block();
+	}
+
+	public void unlinkUser(String accessToken) {
+		webClient.post()
+			.uri(KAUTH_USER_URL_HOST + "/v1/user/unlink")
+			.header(HttpHeaders.AUTHORIZATION, accessToken.startsWith("Bearer ") ? accessToken : "Bearer " + accessToken)
+			.retrieve()
+			.bodyToMono(Void.class)
+			.block();
+	}
+
+}

--- a/src/main/java/com/example/back/teamate/service/UsersService.java
+++ b/src/main/java/com/example/back/teamate/service/UsersService.java
@@ -1,0 +1,81 @@
+package com.example.back.teamate.service;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.example.back.teamate.dto.RedisUserInfoDto;
+import com.example.back.teamate.entity.Users;
+import com.example.back.teamate.dto.KakaoUserInfoResponseDto;
+import com.example.back.teamate.repository.UsersRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UsersService {
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final UsersRepository usersRepository;
+
+	public RedisUserInfoDto registerOrLogin(KakaoUserInfoResponseDto userInfo) {
+		// String kakaoId = String.valueOf(userInfo.getId());
+
+		// 사용자 정보 조회 또는 생성
+		Users user = usersRepository.findByKakaoId(userInfo.getId()).orElseGet(() -> {
+			// 카카오 계정 정보 가져오기
+			KakaoUserInfoResponseDto.KakaoAccount kakaoAccount = userInfo.getKakaoAccount();
+
+			// 이메일 유효성 확인
+			String email = kakaoAccount.getEmail();
+			if (email == null || !kakaoAccount.getIsEmailVerified()) {
+				throw new RuntimeException("이메일 정보가 없거나 인증되지 않았습니다.");
+			}
+
+			// 프로필 정보 가져오기
+			KakaoUserInfoResponseDto.KakaoAccount.Profile profile = kakaoAccount.getProfile();
+
+			// Users 객체 생성 및 저장
+			Users newUser = Users.builder()
+				.kakaoId(userInfo.getId())
+				.email(email)
+				.nickname(profile.getNickname())
+				.profileImage(profile.getProfileImageUrl())
+				.build();
+
+			return usersRepository.save(newUser); // 저장 후 반환
+		});
+
+		// RedisUserInfoDto로 사용자 정보 매핑 및 반환
+		return RedisUserInfoDto.builder()
+			.id(user.getId())
+			.kakaoId(user.getKakaoId())
+			.nickname(user.getNickname())
+			.build();
+	}
+
+
+	public void saveToken(String accessToken, RedisUserInfoDto userData) {
+		String key = "kakao:token:" + accessToken;
+		redisTemplate.opsForValue().set(key, userData, 21600, TimeUnit.SECONDS); // 6시간 TTL
+	}
+
+	public RedisUserInfoDto validateToken(String accessToken) {
+		String key = "kakao:token:" + accessToken;
+		RedisUserInfoDto userData = (RedisUserInfoDto) redisTemplate.opsForValue().get(key);
+
+		if (userData == null) {
+			throw new RuntimeException("유효하지 않은 토큰입니다.");
+		}
+
+		return userData; // 인증된 사용자 데이터 반환
+	}
+
+	public void logout(String accessToken) {
+		String key = "kakao:token:" + accessToken;
+		redisTemplate.delete(key);
+	}
+}


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="557" alt="스크린샷 2024-11-21 오후 8 48 02" src="https://github.com/user-attachments/assets/16f20f84-9c8f-4285-b411-b4fa85d6339d">
localhost:8080/api/v1/login/page 모습입니다.
<img width="1510" alt="스크린샷 2024-11-21 오후 8 48 27" src="https://github.com/user-attachments/assets/bc871a9a-d692-4de0-9de1-d33f69869b70">
teamate.duckdns.org/api/v1/code="로그인후 받는 code"
로그인후 받은 code로 
/api/v1/login에 담아서 보내면 
accessToken 반환하도록 로직 구현하였습니다. 


* redis로 kakao accessToken을 저장하도록 구현하였습니다. 
* Entity에 extends BaseEntity 하면 createdAt, updatedAt 자동 생성되도록 해놓았습니다.
* User는 다른 라이브러리랑 겹칠 수도 있어서 Users로 Entity 만들었습니다.
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
